### PR TITLE
pycoast/cw_base.py added missing ConfigParser import

### DIFF
--- a/pycoast/cw_base.py
+++ b/pycoast/cw_base.py
@@ -33,6 +33,7 @@ from PIL import Image, ImageFont
 import pyproj
 import logging
 from .errors import *
+from ConfigParser import ConfigParser
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Hi

It looks for me that the feature pycairo branch is branched from an old version. Maybe a rebase is better for the feature-pycairo branch than to do this pull request