### PR TITLE
Add AUTHORS list

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,17 @@
+# Project Contributors
+
+The following people have made contributions to this project:
+
+<!--- Use your GitHub account or any other personal reference URL --->
+<!--- See https://gist.github.com/djhoese/52220272ec73b12eb8f4a29709be110d for auto-generating parts of this list --->
+
+- Stefano Cerino
+- [Adam Dybbroe (adybbroe)](https://github.com/adybbroe)
+- [David Hoese (djhoese)](https://github.com/djhoese)
+- [Katja Hungershofer (khunger)](https://github.com/khunger)
+- [Mikhail Itkin (mitkin)](https://github.com/mitkin)
+- [Panu Lahtinen (pnuu)](https://github.com/pnuu)
+- [Esben S. Nielsen (storpipfugl)](https://github.com/storpipfugl)
+- [Martin Raspaud (mraspaud)](https://github.com/mraspaud)
+- [Hrobjartur Thorsteinsson (thorsteinssonh)](https://github.com/thorsteinssonh)
+- [Antonio Valentino (avalentino)](https://github.com/avalentino)

--- a/README
+++ b/README
@@ -1,4 +1,1 @@
-Python package for adding coastlines and borders to raster images.
-
-Look at http://code.google.com/p/pycoast/ and http://pytroll.org/ for more information.
-
+README.rst

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,38 @@
+PyCoast
+=======
+
+.. image:: https://travis-ci.org/pytroll/pycoast.svg?branch=master
+    :target: https://travis-ci.org/pytroll/pycoast
+
+.. image:: https://img.shields.io/pypi/v/pycoast.svg
+        :target: https://pypi.python.org/pypi/pycoast
+
+Python package for adding coastlines and borders to raster images.
+
+Installation
+------------
+
+PyCoast can be installed from PyPI using pip::
+
+    pip install pycoast
+
+Or with conda using the conda-forge channel::
+
+    conda install -c conda-forge pycoast
+
+Example
+-------
+
+::
+
+    >>> from PIL import Image
+    >>> from pycoast import ContourWriterAGG
+    >>> img = Image.open('BMNG_clouds_201109181715_areaT2.png')
+    >>> proj4_string = '+proj=stere +lon_0=8.00 +lat_0=50.00 +lat_ts=50.00 +ellps=WGS84'
+    >>> area_extent = (-3363403.31,-2291879.85,2630596.69,2203620.1)
+    >>> area_def = (proj4_string, area_extent)
+    >>> cw = ContourWriterAGG('/home/esn/data/gshhs')
+    >>> cw.add_coastlines(img, area_def, resolution='l', level=4)
+    >>> cw.add_rivers(img, area_def, level=5, outline='blue')
+    >>> cw.add_borders(img, area_def, outline=(255, 0, 0))
+    >>> img.show()

--- a/pycoast/cw_agg.py
+++ b/pycoast/cw_agg.py
@@ -2,12 +2,7 @@
 # -*- coding: utf-8 -*-
 # pycoast, Writing of coastlines, borders and rivers to images in Python
 #
-# Copyright (C) 2011-2015
-#    Esben S. Nielsen
-#    Hróbjartur Þorsteinsson
-#    Stefano Cerino
-#    Katja Hungershofer
-#    Panu Lahtinen
+# Copyright (C) 2011-2018 PyCoast Developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/pycoast/cw_base.py
+++ b/pycoast/cw_base.py
@@ -2,12 +2,7 @@
 # -*- coding: utf-8 -*-
 # pycoast, Writing of coastlines, borders and rivers to images in Python
 #
-# Copyright (C) 2011-2015
-#    Esben S. Nielsen
-#    Hróbjartur Þorsteinsson
-#    Stefano Cerino
-#    Katja Hungershofer
-#    Panu Lahtinen
+# Copyright (C) 2011-2018 PyCoast Developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/pycoast/cw_pil.py
+++ b/pycoast/cw_pil.py
@@ -1,18 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# pycoast, Writing of coastlines, borders and rivers to images in Python
+# pycoast, Writing of coastlines, borders, and rivers to images in Python
 #
-# Copyright (C) 2011-2015
-#    Esben S. Nielsen
-#    Hróbjartur Þorsteinsson
-#    Stefano Cerino
-#    Katja Hungershofer
-#    Panu Lahtinen
+# Copyright (C) 2011-2018 PyCoast Developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/pycoast/tests/test_pycoast.py
+++ b/pycoast/tests/test_pycoast.py
@@ -1,6 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # pycoast, Writing of coastlines, borders and rivers to images in Python
 #
-# Copyright (C) 2011, 2016  Esben S. Nielsen
+# Copyright (C) 2011-2018 PyCoast Developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 # pycoast, Writing of coastlines, borders and rivers to images in Python
 #
-# Copyright (C) 2011, 2014, 2016  Esben S. Nielsen
+# Copyright (C) 2011-2018 PyCoast Developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
-#(at your option) any later version.
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -20,10 +20,14 @@ import versioneer
 
 requires = ['aggdraw', 'pyshp', 'numpy', 'pyproj', 'pillow', 'six']
 
+with open('README', 'r') as readme_file:
+    long_description = readme_file.read()
+
 setup(name='pycoast',
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
       description='Writing of coastlines, borders and rivers to images in Python',
+      long_description=long_description,
       author='Esben S. Nielsen',
       author_email='esn@dmi.dk',
       packages=['pycoast', 'pycoast.tests'],


### PR DESCRIPTION
Similar to other pytroll packages I added an AUTHORS.md file to list the authors/contributors to pycoast. This includes updates to the copyright statement on each file to specify "PyCoast Developers" instead of each individual's name. This should make it easier in the future to keep the list of AUTHORS of the project up to date.

I also added more documentation/information to the README.
