### PR TITLE
Add deprecation warning if using ContourWriter

### DIFF
--- a/pycoast/__init__.py
+++ b/pycoast/__init__.py
@@ -9,6 +9,14 @@ from .cw_agg import ContourWriterAGG
 
 
 class ContourWriter(ContourWriterPIL):
+    """Writer wrapper for deprecation warning.
+
+    .. deprecated:: 1.2.0
+
+        Use :class:`~pycoast.cw_pil.ContourWriterPIL` or :class:`~pycoast.cw_agg.ContourWriterAGG` instead.
+
+    """
+
     def __init__(self, *args, **kwargs):
         import warnings
         warnings.warn("'ContourWriter' has been deprecated please use "

--- a/pycoast/__init__.py
+++ b/pycoast/__init__.py
@@ -6,5 +6,11 @@ del get_versions
 
 from .cw_pil import ContourWriterPIL
 from .cw_agg import ContourWriterAGG
-ContourWriter = ContourWriterAGG
 
+
+class ContourWriter(ContourWriterPIL):
+    def __init__(self, *args, **kwargs):
+        import warnings
+        warnings.warn("'ContourWriter' has been deprecated please use "
+                      "'ContourWriterPIL' or 'ContourWriterAGG' instead", DeprecationWarning)
+        super(ContourWriter, self).__init__(*args, **kwargs)


### PR DESCRIPTION
After talking with @mraspaud, he pointed out that this is the better way to deprecate this.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
