### PR TITLE
Fix default font loading for 'add_grid'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
   global:
   # Set defaults to avoid repeating in most cases
   - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
-  - NUMPY_VERSION=stable
+  - NUMPY_VERSION=1.15
   - MAIN_CMD='python setup.py'
   - CONDA_DEPENDENCIES='sphinx pillow numpy pyproj coveralls coverage mock aggdraw six pyshp'
   - PIP_DEPENDENCIES=''

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ env:
   global:
   # Set defaults to avoid repeating in most cases
   - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
-  - NUMPY_VERSION=1.15
+  - NUMPY_VERSION=stable
   - MAIN_CMD='python setup.py'
-  - CONDA_DEPENDENCIES='sphinx pillow numpy pyproj coveralls coverage mock aggdraw six pyshp'
+  - CONDA_DEPENDENCIES='sphinx pillow pyproj coveralls coverage mock aggdraw six pyshp'
   - PIP_DEPENDENCIES=''
   - SETUP_XVFB=False
   - EVENT_TYPE='push pull_request'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
     os: linux
   - env: PYTHON_VERSION=3.6
     os: osx
+  - env: PYTHON_VERSION=3.6
+    os: windows
 install:
 - git clone --depth 1 git://github.com/astropy/ci-helpers.git
 - source ci-helpers/travis/setup_conda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
     os: osx
   - env: PYTHON_VERSION=3.6
     os: windows
+    language: bash
 install:
 - git clone --depth 1 git://github.com/astropy/ci-helpers.git
 - source ci-helpers/travis/setup_conda.sh

--- a/pycoast/cw_base.py
+++ b/pycoast/cw_base.py
@@ -76,6 +76,9 @@ class ContourWriterBase(object):
     def _draw_grid_labels(self, draw, xys, linetype, txt, font, **kwargs):
         """Draw text with default PIL module
         """
+        if font is None:
+            # NOTE: Default font does not use font size in PIL writer
+            font = self._get_font(kwargs.get('outline', 'black'), font, 12)
         placement_def = kwargs[linetype].lower()
         for xy in xys:
             # note xy[0] is xy coordinate pair,
@@ -173,9 +176,6 @@ class ContourWriterBase(object):
                 kwargs['minor_outline_opacity']
             minor_line_kwargs['width'] = kwargs['minor_width']
 
-        # set text fonts
-        if font is None:
-            font = ImageFont.load_default()
         # text margins (at sides of image frame)
         y_text_margin = 4
         x_text_margin = 4

--- a/pycoast/cw_pil.py
+++ b/pycoast/cw_pil.py
@@ -464,4 +464,6 @@ class ContourWriterPIL(ContourWriterBase):
 
     def _get_font(self, outline, font_file, font_size):
         """Return a font."""
+        if font_file is None:
+            return ImageFont.load_default()
         return ImageFont.truetype(font_file, font_size)


### PR DESCRIPTION
I think this has always been an issue but has become very apparent in my own code after switching to the AGG contour writer by default. The main issue is that the `_add_grid` method in the base writer will try to load a default font object if one is not provided. It was using `PIL.ImageFont.load_default()` to get an `ImageFont` object to use. The issue with that is that `aggdraw` does not handle `ImageFont` objects, it only handles `aggdraw.Font` objects.

This PR adds a font loading method implemented by the writer subclasses. It also moves the font loading in to the label adding method so it isn't loaded unless labels are actually going to be written.

This is a short term fix. The long term fix should some how handle the differences between `ImageFont` which accepts font path and size only and `Font` accepts color (outline), font path, and size. Even worse the `ImageFont.load_default()` returned font can't have its size specified or changed which is...not very useful.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
