### PR TITLE
Fix pyproj 2.2+ is_latlong compatibility

### DIFF
--- a/pycoast/cw_base.py
+++ b/pycoast/cw_base.py
@@ -32,6 +32,16 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+class Proj(pyproj.Proj):
+    """Wrapper around pyproj to add in 'is_latlong'."""
+
+    def is_latlong(self):
+        if hasattr(pyproj.Proj, 'is_latlong'):
+            # pyproj<2.2
+            return super(Proj, self).is_latlong()
+        return self.crs.is_geographic
+
+
 class ContourWriterBase(object):
     """Base class for contourwriters. Do not instantiate.
 
@@ -182,7 +192,7 @@ class ContourWriterBase(object):
 
         # Area and projection info
         x_size, y_size = image.size
-        prj = pyproj.Proj(proj4_string)
+        prj = Proj(proj4_string)
 
         x_offset = 0
         y_offset = 0
@@ -512,7 +522,7 @@ class ContourWriterBase(object):
 
         # Area and projection info
         x_size, y_size = image.size
-        prj = pyproj.Proj(proj4_string)
+        prj = Proj(proj4_string)
 
         # Calculate min and max lons and lats of interest
         lon_min, lon_max, lat_min, lat_max = _get_lon_lat_bounding_box(area_extent, x_size, y_size, prj)
@@ -690,7 +700,7 @@ class ContourWriterBase(object):
         foreground = Image.new('RGBA', (x_size, y_size), (0, 0, 0, 0))
 
         # Lines (coasts, rivers, borders) management
-        prj = pyproj.Proj(area_def.proj4_string)
+        prj = Proj(area_def.proj4_string)
         if prj.is_latlong():
             x_ll, y_ll = prj(area_def.area_extent[0], area_def.area_extent[1])
             x_ur, y_ur = prj(area_def.area_extent[2], area_def.area_extent[3])
@@ -814,7 +824,7 @@ class ContourWriterBase(object):
 
         # Area and projection info
         x_size, y_size = image.size
-        prj = pyproj.Proj(proj4_string)
+        prj = Proj(proj4_string)
 
         # read shape file with points
         # Sc-Kh shapefilename = os.path.join(self.db_root_path,

--- a/pycoast/cw_base.py
+++ b/pycoast/cw_base.py
@@ -36,10 +36,10 @@ class Proj(pyproj.Proj):
     """Wrapper around pyproj to add in 'is_latlong'."""
 
     def is_latlong(self):
-        if hasattr(pyproj.Proj, 'is_latlong'):
-            # pyproj<2.2
-            return super(Proj, self).is_latlong()
-        return self.crs.is_geographic
+        if hasattr(self, 'crs'):
+            return self.crs.is_geographic
+        # pyproj<2.0
+        return super(Proj, self).is_latlong()
 
 
 class ContourWriterBase(object):


### PR DESCRIPTION
Pyproj 2.2+ no longer has a `Proj.is_latlong` method. It has been replaced by a `Proj.crs.is_geographic` property. This PR adds a wrapper around Proj to fix this until we require pyproj 2.0+.

 - [x] Closes #27 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
