### PR TITLE
Fix the add overlay function to accept `minor_is_tick` as a boolean

### DIFF
--- a/pycoast/cw_base.py
+++ b/pycoast/cw_base.py
@@ -850,9 +850,9 @@ class ContourWriterBase(object):
                     font = truetype(font, font_size)
             fill = overlays['grid'].get('fill', None)
             minor_outline = overlays['grid'].get('minor_outline', 'white')
-            minor_is_tick = overlays['grid'].get('minor_is_tick',
-                                                 'true').lower() in \
-                ['true', 'yes', '1']
+            minor_is_tick = overlays['grid'].get('minor_is_tick', True)
+            if isinstance(minor_is_tick, str):
+                minor_is_tick = minor_is_tick.lower() in ['true', 'yes', '1']
             lon_placement = overlays['grid'].get('lon_placement', 'tb')
             lat_placement = overlays['grid'].get('lat_placement', 'lr')
 

--- a/pycoast/tests/test_pycoast.py
+++ b/pycoast/tests/test_pycoast.py
@@ -812,6 +812,13 @@ class TestFromConfig(TestPycoast):
         self.assertNotEqual(os.path.getmtime(cache_filename), mtime)
         self.assertTrue(fft_metric(euro_data, res),
                         'Writing of contours failed')
+
+        overlays.pop('cache')
+        overlays['grid'] = {'outline': (255, 255, 255), 'outline_opacity': 175,
+                            'minor_outline': (200, 200, 200), 'minor_outline_opacity': 127,
+                            'width': 1.0, 'minor_width': 0.5, 'minor_is_tick': True,
+                            'write_text': True, 'lat_placement': 'lr', 'lon_placement': 'b'}
+        img = cw.add_overlay_from_dict(overlays, area_def)
         os.remove(os.path.join(tmp, 'pycoast_cache_fakearea.png'))
 
     def test_get_resolution(self):


### PR DESCRIPTION
This was introduced in #32

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
