### PR TITLE
Fix cached overlays always being regenerated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## Version 1.3.2 (2019/12/06)
+
+### Issues Closed
+
+* [Issue 39](https://github.com/pytroll/pycoast/issues/39) - distorted/strange coastlines with pyproj-2.4.2 ([PR 40](https://github.com/pytroll/pycoast/pull/40))
+
+In this release 1 issue was closed.
+
+### Pull Requests Merged
+
+#### Bugs fixed
+
+* [PR 40](https://github.com/pytroll/pycoast/pull/40) - Fix compatibility with pyproj 2.4.2 and reduce generated warnings ([39](https://github.com/pytroll/pycoast/issues/39))
+* [PR 38](https://github.com/pytroll/pycoast/pull/38) - Remove unnecessary casting in adding overlay from dictionary
+
+In this release 2 pull requests were closed.
+
+
 ## Version 1.3.1 (2019/11/07)
 
 ### Pull Requests Merged

--- a/pycoast/cw_base.py
+++ b/pycoast/cw_base.py
@@ -721,24 +721,31 @@ class ContourWriterBase(object):
             area_def : object
                 Area Definition of the creating image
             cache_epoch: seconds since epoch
-                The latest time allowed for cache the cache file. If the cache file is older
-                than this (mtime), the cache should be regenerated.
+                The latest time allowed for cache the cache file. If the cache
+                file is older than this (mtime), the cache should be
+                regenerated. Defaults to 0 meaning always reuse the cached
+                file if it exists. Requires "cache" to be configured in the
+                provided dictionary (see below).
             background: pillow image instance
                 The image on which to write the overlays on. If it's None (default),
-                a new image is created, otherwise the provide background is use
-                an change *in place*.
+                a new image is created, otherwise the provide background is
+                used and changed *in place*.
 
 
             The keys in `overlays` that will be taken into account are:
             cache, coasts, rivers, borders, cities, points, grid
 
-            For all of them except `cache`, the items are the same as the corresponding
-            functions in pycoast, so refer to the docstrings of these functions
-            (add_coastlines, add_rivers, add_borders, add_grid, add_cities, add_points).
-            For cache, two parameters are configurable: `file` which specifies the directory
-            and the prefix of the file to save the caches decoration to
-            (for example /var/run/black_coasts_red_borders), and `regenerate` that can be
-            True or False (default) to force the overwriting of an already cached file.
+            For all of them except `cache`, the items are the same as the
+            corresponding functions in pycoast, so refer to the docstrings of
+            these functions (add_coastlines, add_rivers, add_borders,
+            add_grid, add_cities, add_points). For cache, two parameters are
+            configurable:
+
+            - `file`: specify the directory and the prefix
+                  of the file to save the caches decoration to (for example
+                  /var/run/black_coasts_red_borders)
+            - `regenerate`: True or False (default) to force the overwriting
+                  of an already cached file.
 
         """
 
@@ -749,7 +756,7 @@ class ContourWriterBase(object):
                           area_def.area_id + '.png')
 
             try:
-                config_time = cache_epoch
+                config_time = cache_epoch or 0
                 cache_time = os.path.getmtime(cache_file)
                 # Cache file will be used only if it's newer than config file
                 if ((config_time is not None and config_time < cache_time)

--- a/pycoast/tests/test_pycoast.py
+++ b/pycoast/tests/test_pycoast.py
@@ -917,30 +917,37 @@ class TestFromConfig(TestPycoast):
                     'borders': {'outline': (255, 0, 0), 'resolution': 'c'},
                     'rivers': {'outline': 'blue', 'resolution': 'c', 'level': 5}}
 
+        # Create the original cache file
         cache_filename = os.path.join(tmp, 'pycoast_cache_fakearea.png')
         img = cw.add_overlay_from_dict(overlays, area_def)
         res = np.array(img)
         self.assertTrue(fft_metric(euro_data, res),
                         'Writing of contours failed')
         self.assertTrue(os.path.isfile(cache_filename))
-
-        current_time = time.time()
-
-        img = cw.add_overlay_from_dict(overlays, area_def, current_time)
-
         mtime = os.path.getmtime(cache_filename)
 
+        # Reuse the generated cache file
+        img = cw.add_overlay_from_dict(overlays, area_def)
+        res = np.array(img)
+        self.assertTrue(fft_metric(euro_data, res),
+                        'Writing of contours failed')
+        self.assertTrue(os.path.isfile(cache_filename))
+        self.assertEqual(os.path.getmtime(cache_filename), mtime)
+
+        # Regenerate cache file
+        current_time = time.time()
+        cw.add_overlay_from_dict(overlays, area_def, current_time)
+        mtime = os.path.getmtime(cache_filename)
         self.assertGreater(mtime, current_time)
         self.assertTrue(fft_metric(euro_data, res),
                         'Writing of contours failed')
 
-        img = cw.add_overlay_from_dict(overlays, area_def, current_time)
-
+        cw.add_overlay_from_dict(overlays, area_def, current_time)
         self.assertEqual(os.path.getmtime(cache_filename), mtime)
         self.assertTrue(fft_metric(euro_data, res),
                         'Writing of contours failed')
         overlays['cache']['regenerate'] = True
-        img = cw.add_overlay_from_dict(overlays, area_def)
+        cw.add_overlay_from_dict(overlays, area_def)
 
         self.assertNotEqual(os.path.getmtime(cache_filename), mtime)
         self.assertTrue(fft_metric(euro_data, res),


### PR DESCRIPTION
Ernst on the mailing list pointed out that when using `add_overlay_from_dict` it is possible to configure a cache to be used but the default `cache_epoch` setting was always regenerating the cached file. It never actually used the file being generated.

Side note: I noticed I apparently never committed the changelog for 1.3.2. I'm tacking that onto this PR.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
