### PR TITLE
Remove Python 3.7 from CI testing for now

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.7", "3.9"]
+        python-version: ["3.9"]
         experimental: [false]
         include:
           - python-version: "3.9"

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -3,12 +3,13 @@ channels:
   - conda-forge
 dependencies:
   - sphinx
-  - pillow
-  - pyproj
+  - pillow=8.3.2
+  - pyproj=3.2.1
+  - numpy=1.19.5
   - coveralls
   - coverage
-  - aggdraw
-  - pyshp
-  - pyresample
+  - aggdraw=1.3.12
+  - pyshp=2.1.3
+  - pyresample=1.21.1
   - pytest
   - pytest-cov


### PR DESCRIPTION
Testing to see if I can produce the same failure in #57 but on our own CI.

1. Use the existing setup for Python 3.9 and see what dependencies get pulled in.
2. Force the dependencies from the failed debian build.
3. ...give up on CI testing probably
4. Try a debian docker image with conda-forge packages (should be similar to CI)
5. Last resort, try debian packages in the docker image