### PR TITLE
Fix sphinx build in source dir

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,12 +16,12 @@ from __future__ import annotations
 import os
 import sys
 
-from pycoast import __version__
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath("../../"))
+
+from pycoast import __version__
 
 # -- General configuration -----------------------------------------------------
 


### PR DESCRIPTION
The sphinx documentation cannot be built from the source directory.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
