### PR TITLE
Fix numpy 2 compatibility

### DIFF
--- a/pycoast/cw_base.py
+++ b/pycoast/cw_base.py
@@ -1521,7 +1521,7 @@ class _GridDrawer:
         min_lons[min_lons > 180] = min_lons[min_lons > 180] - 360
 
         # Get min_lons not in maj_lons
-        min_lons = np.lib.arraysetops.setdiff1d(min_lons, maj_lons)
+        min_lons = np.setdiff1d(min_lons, maj_lons)
 
         # lats along major lon lines
         lin_lats = np.arange(
@@ -1542,7 +1542,7 @@ class _GridDrawer:
         min_lats = np.arange(round_lat_min + increase_min_lat, lat_max - shorten_max_lat, dlat)
 
         # Get min_lats not in maj_lats
-        min_lats = np.lib.arraysetops.setdiff1d(min_lats, maj_lats)
+        min_lats = np.setdiff1d(min_lats, maj_lats)
 
         # lons along major lat lines (extended slightly to avoid missing the end)
         lin_lons = np.linspace(lon_min, lon_max + Dlon / 5.0, max(self._x_size, self._y_size) // 5)

--- a/pycoast/tests/test_pycoast.py
+++ b/pycoast/tests/test_pycoast.py
@@ -1900,6 +1900,7 @@ class TestFromConfig:
         # Create the original cache file
         img = cw.add_overlay_from_dict(overlays, area_def)
         res = np.array(img)
+        img.close()
         cache_glob = glob(os.path.join(tmpdir, "pycoast_cache_*.png"))
         assert len(cache_glob) == 1
         cache_filename = cache_glob[0]
@@ -1910,22 +1911,26 @@ class TestFromConfig:
         # Reuse the generated cache file
         img = cw.add_overlay_from_dict(overlays, area_def)
         res = np.array(img)
+        img.close()
         assert fft_metric(euro_data, res), "Writing of contours failed"
         assert os.path.isfile(cache_filename)
         assert os.path.getmtime(cache_filename) == mtime
 
         # Regenerate cache file
         current_time = time.time()
-        cw.add_overlay_from_dict(overlays, area_def, current_time)
+        fg_img = cw.add_overlay_from_dict(overlays, area_def, current_time)
+        fg_img.close()
         mtime = os.path.getmtime(cache_filename)
         assert mtime > current_time
         assert fft_metric(euro_data, res), "Writing of contours failed"
 
-        cw.add_overlay_from_dict(overlays, area_def, current_time)
+        fg_img = cw.add_overlay_from_dict(overlays, area_def, current_time)
+        fg_img.close()
         assert os.path.getmtime(cache_filename) == mtime
         assert fft_metric(euro_data, res), "Writing of contours failed"
         overlays["cache"]["regenerate"] = True
-        cw.add_overlay_from_dict(overlays, area_def)
+        fg_img = cw.add_overlay_from_dict(overlays, area_def)
+        fg_img.close()
 
         assert os.path.getmtime(cache_filename) != mtime
         assert fft_metric(euro_data, res), "Writing of contours failed"
@@ -1943,7 +1948,8 @@ class TestFromConfig:
             "lat_placement": "lr",
             "lon_placement": "b",
         }
-        cw.add_overlay_from_dict(overlays, area_def)
+        fg_img = cw.add_overlay_from_dict(overlays, area_def)
+        fg_img.close()
         os.remove(cache_filename)
 
     def test_caching_with_param_changes(self, tmpdir):
@@ -1962,7 +1968,8 @@ class TestFromConfig:
         }
 
         # Create the original cache file
-        cw.add_overlay_from_dict(overlays, area_def)
+        fg_img = cw.add_overlay_from_dict(overlays, area_def)
+        fg_img.close()
         cache_glob = glob(os.path.join(tmpdir, "pycoast_cache_*.png"))
         assert len(cache_glob) == 1
         cache_filename = cache_glob[0]
@@ -1970,7 +1977,8 @@ class TestFromConfig:
         mtime = os.path.getmtime(cache_filename)
 
         # Reuse the generated cache file
-        cw.add_overlay_from_dict(overlays, area_def)
+        fg_img = cw.add_overlay_from_dict(overlays, area_def)
+        fg_img.close()
         cache_glob = glob(os.path.join(tmpdir, "pycoast_cache_*.png"))
         assert len(cache_glob) == 1
         assert os.path.isfile(cache_filename)
@@ -1979,7 +1987,8 @@ class TestFromConfig:
         # Remove the font option, should produce the same result
         # font is not considered when caching
         del overlays["grid"]["font"]
-        cw.add_overlay_from_dict(overlays, area_def)
+        fg_img = cw.add_overlay_from_dict(overlays, area_def)
+        fg_img.close()
         cache_glob = glob(os.path.join(tmpdir, "pycoast_cache_*.png"))
         assert len(cache_glob) == 1
         assert os.path.isfile(cache_filename)
@@ -1990,7 +1999,8 @@ class TestFromConfig:
             "cache": {"file": os.path.join(tmpdir, "pycoast_cache")},
             "grid": {"width": 2.0},
         }
-        cw.add_overlay_from_dict(overlays, area_def)
+        fg_img = cw.add_overlay_from_dict(overlays, area_def)
+        fg_img.close()
         cache_glob = glob(os.path.join(tmpdir, "pycoast_cache_*.png"))
         assert len(cache_glob) == 2
         assert os.path.isfile(cache_filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,9 @@ exclude = '''
 )
 
 '''
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",
+    "ignore:numpy.ndarray size changed:RuntimeWarning",
+]


### PR DESCRIPTION
Fixes use of deprecated functions from numpy. It also adds checks for warnings durings tests and I've removed the small number of existing warnings.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
