### PR TITLE
Modernize by using ruff

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,3 +1,0 @@
-[bandit]
-skips: B506
-exclude: pycoast/tests,pycoast/version.py,versioneer.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.12", "3.13", "3.14"]
         experimental: [false]
         include:
           - python-version: "3.12"

--- a/.gitignore
+++ b/.gitignore
@@ -1,68 +1,37 @@
-# Created by .ignore support plugin (hsz.mobi)
-### Python template
-# Byte-compiled / optimized / DLL files
+# Byte-compiled / caches
 __pycache__/
 *.py[cod]
-*$py.class
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.cache/
 
-# C extensions
-*.so
+# Environments
+.venv/
+venv/
+env/
 
 # Distribution / packaging
-.Python
-env/
 build/
-develop-eggs/
 dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
 *.egg-info/
-.installed.cfg
-*.egg
+.eggs/
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
+# Coverage
 .coverage
 .coverage.*
-.cache
-nosetests.xml
+htmlcov/
 coverage.xml
-*,cover
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-
-# Sphinx documentation
+# Docs
+docs/build/
 docs/_build/
+docs/source/api/
 
-# PyBuilder
-target/
+# Editors / IDEs
+.idea/
+.vscode/
+.ropeproject/
 
-doc/source/api/*.rst
-
-# pycharm
-.idea
-
-# rope
-.ropeproject
+# Local scratch
+res.png

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     rev: 'v0.15.11'
     hooks:
       - id: ruff-check
+      - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -13,7 +14,6 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
         args: [--unsafe]
-      - id: no-commit-to-branch
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v2.3.0'  # Use the sha / tag you want to point at
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,11 @@
 exclude: '^$'
 fail_fast: false
+
 repos:
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.5.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 'v0.15.11'
     hooks:
-      - id: black
-        language_version: python3
-        exclude: (versioneer\.py|pycoast\/version\.py)
-        args:
-          - --target-version=py38
-  - repo: https://github.com/pycqa/isort
-    rev: 9.0.0a3
-    hooks:
-      - id: isort
-        language_version: python3
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.3.0
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-docstrings, flake8-debugger, flake8-bugbear, mccabe]
-        args: [--max-complexity, "10"]
+      - id: ruff-check
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -27,11 +13,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
         args: [--unsafe]
-  - repo: https://github.com/PyCQA/bandit
-    rev: '1.9.4'
-    hooks:
-      - id: bandit
-        args: [--ini, .bandit]
+      - id: no-commit-to-branch
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v2.1.0'  # Use the sha / tag you want to point at
     hooks:
@@ -41,6 +23,7 @@ repos:
           - types-setuptools
           - types-PyYAML
           - types-requests
+
 ci:
   # To trigger manually, comment on a pull request with "pre-commit.ci autofix"
   autofix_prs: false

--- a/pycoast/__init__.py
+++ b/pycoast/__init__.py
@@ -25,7 +25,7 @@ class ContourWriter(ContourWriterPIL):
         import warnings
 
         warnings.warn(
-            "'ContourWriter' has been deprecated please use " "'ContourWriterPIL' or 'ContourWriterAGG' instead",
+            "'ContourWriter' has been deprecated please use 'ContourWriterPIL' or 'ContourWriterAGG' instead",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/pycoast/conftest.py
+++ b/pycoast/conftest.py
@@ -1,9 +1,9 @@
 """The conftest file."""
 
-from pytest import hookimpl
+import pytest
 
 
-@hookimpl(tryfirst=True, hookwrapper=True)
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     """Add test status in the report for fixtures to use."""
     # execute all other hooks to obtain the report object

--- a/pycoast/cw_base.py
+++ b/pycoast/cw_base.py
@@ -103,7 +103,7 @@ class _CoordConverter:
             y += area_def.height
         if x < 0 or y < 0 or x >= area_def.width or y >= area_def.height:
             raise ValueError(
-                "Image pixel coords out of image bounds " f"(width={area_def.width}, height={area_def.height})."
+                f"Image pixel coords out of image bounds (width={area_def.width}, height={area_def.height})."
             )
         return x, y
 

--- a/pycoast/cw_base.py
+++ b/pycoast/cw_base.py
@@ -425,8 +425,8 @@ class ContourWriterBase(object):
             try:
                 s = shapefile.Reader(shapefilename)
                 shapes = s.shapes()
-            except AttributeError:
-                raise ValueError("Could not find shapefile %s" % shapefilename)
+            except AttributeError as err:
+                raise ValueError("Could not find shapefile %s" % shapefilename) from err
 
             yield from shapes
 
@@ -697,8 +697,8 @@ class ContourWriterBase(object):
 
         try:
             from pyresample.geometry import AreaDefinition
-        except ImportError:
-            raise ImportError("Missing required 'pyresample' module, please install it.")
+        except ImportError as err:
+            raise ImportError("Missing required 'pyresample' module, please install it.") from err
 
         if not isinstance(area_def, AreaDefinition):
             raise ValueError("Expected 'area_def' is an instance of AreaDefinition object")
@@ -1268,6 +1268,7 @@ class _OverlaysFromDict:
         for section, fun in zip(
             ["coasts", "rivers", "borders"],
             [self._cw.add_coastlines, self._cw.add_rivers, self._cw.add_borders],
+            strict=True,
         ):
             if section not in overlays:
                 continue

--- a/pycoast/tests/test_pycoast.py
+++ b/pycoast/tests/test_pycoast.py
@@ -331,7 +331,7 @@ def test_file_path(tmp_path):
     path = tmp_path / test_filename
     img = Image.new("RGB", (640, 480))
     img.save(path)
-    yield path
+    return path
 
 
 @pytest.fixture
@@ -340,7 +340,7 @@ def grid_file_path(tmp_path):
     path = tmp_path / grid_filename
     img = Image.new("RGB", (640, 480))
     img.save(path)
-    yield path
+    return path
 
 
 class TestContourWriterPIL:
@@ -385,7 +385,7 @@ class TestContourWriterPIL:
         assert images_match(geos_img, img), "Writing of geos contours failed"
 
     @pytest.mark.parametrize(
-        "filename, shape, area_def, level, grid_kwargs",
+        ("filename", "shape", "area_def", "level", "grid_kwargs"),
         [
             (
                 "grid_europe.png",
@@ -690,7 +690,7 @@ class TestContourWriterPIL:
         area_def = nh_def(shape)
         img1 = Image.new("RGB", shape[::-1], (255, 255, 255))
         points_list = [((0, 0), "Berlin")]
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="'coord_ref' must be one of"):
             cw_pil.add_points(
                 img1,
                 area_def,
@@ -952,7 +952,7 @@ class TestContourWriterPIL:
 
 
 @pytest.mark.parametrize(
-    "cw, filename, area_def, specific_kwargs",
+    ("cw", "filename", "area_def", "specific_kwargs"),
     [
         (
             lazy_fixture("cw_pil"),
@@ -1020,7 +1020,7 @@ def test_shapes(new_test_image, cw, filename, area_def, specific_kwargs):
 
 
 @pytest.mark.parametrize(
-    "cw, filename, shape, area_def, specific_kwargs",
+    ("cw", "filename", "shape", "area_def", "specific_kwargs"),
     [
         (  # lon=175 +/-40, lat=16..65 | Avoid Eurasia scratch with asymmetric area_extent
             lazy_fixture("cw_pil"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.ruff]
 line-length = 120
+target-version = "py312"
 extend-exclude = ["versioneer.py", "pycoast/version.py"]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,18 +2,27 @@
 requires = ["setuptools >= 40.9.0", "wheel", "oldest-supported-numpy", "versioneer-518"]
 build-backend = "setuptools.build_meta"
 
-[tool.black]
+[tool.ruff]
 line-length = 120
-exclude = '''
-(
-  \.git
-  | build
-  | dist
-  | versioneer\.py
-  | pycoast/version\.py
-)
+extend-exclude = ["versioneer.py", "pycoast/version.py"]
 
-'''
+[tool.ruff.lint]
+# See https://docs.astral.sh/ruff/rules/
+select = ["A", "B", "D", "E", "W", "F", "I", "N", "PT", "S", "TID", "C90", "Q", "T10", "T20"]
+# D102/D107 were already ignored under flake8; the affected legacy methods are being replaced
+ignore = ["D102", "D107"]
+
+[tool.ruff.lint.per-file-ignores]
+"pycoast/tests/*" = ["S101", "T201"]  # assert and diagnostic prints allowed in tests
+"docs/source/conf.py" = ["D100", "A001"]
+# Dlon/Dlat & co are public API until 2.0; DEFAULT_* locals go away with the legacy modules
+"pycoast/cw_*.py" = ["N803", "N806"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/scripts/create_contributor_map.py
+++ b/scripts/create_contributor_map.py
@@ -149,7 +149,7 @@ def main():
         )
         zip_fn = "ne_110m_admin_0_countries.zip"
         LOG.info("Downloading NaturalEarth Shapefile")
-        with urllib.request.urlopen(url) as response, open(zip_fn, "wb") as out_file:  # nosec: B310
+        with urllib.request.urlopen(url) as response, open(zip_fn, "wb") as out_file:  # noqa: S310
             shutil.copyfileobj(response, out_file)
         zip_ref = zipfile.ZipFile(zip_fn, "r")
         zip_ref.extractall(".")

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,13 +3,6 @@ requires = pyshp python-pillow aggdraw
 release = 1
 doc_files = docs/Makefile docs/source/*.rst
 
-[flake8]
-max-line-length = 120
-ignore = D107,D102,W503,E203
-exclude =
-    pycoast/version.py
-    versioneer.py
-
 [versioneer]
 VCS = git
 style = pep440
@@ -22,12 +15,3 @@ relative_files = True
 omit =
     pycoast/version.py
     versioneer.py
-
-[isort]
-sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-profile = black
-skip_gitignore = true
-force_to_top = true
-default_section = THIRDPARTY
-known_first_party = pycoast
-skip=.gitignore,versioneer.py,pycoast/version.py

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     include_package_data=True,
     install_requires=requires,
     extras_require=extras_require,
-    python_requires=">3.9",
+    python_requires=">=3.12",
     zip_safe=False,
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Replace black, isort, flake8 (+plugins), bandit with ruff.
Modernize .gitignore and slim pre-commit to four hooks.
